### PR TITLE
cukinia: make log prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ A cukinia config file supports the following statements:
 * ``cukinia_run_dir <directory>``: Runs all executables in directory as individual tests
 * ``cukinia_log <message>``: Logs message to stdout
 
+### Logging customization
+
+* ``logging prefix "string"``: prefix logs with "string"
+
 ### Useful variables
 
 * ``$cukinia_tests``: number of tests attempted

--- a/cukinia
+++ b/cukinia
@@ -51,10 +51,28 @@ cukinia_conf_include()
 	done
 }
 
+# logging: change log string format
+# args: prefix "str" - prefix logs with "str"
+logging()
+{
+	case "$1" in
+	prefix)
+		shift
+		__log_pfx="$@"
+		;;
+	*)
+		cukinia_log "logging: invalid parameter"
+		return 1
+		;;
+	esac
+
+	return 0
+}
+
 # cukinia_log: log arguments to stdout
 cukinia_log()
 {
-	echo "cukinia: $@"
+	echo "${__log_pfx}$@"
 }
 
 # run the test and its context
@@ -173,7 +191,7 @@ _cukinia_result()
 		;;
 	esac
 
-	cukinia_log "[$result] : $__cukinia_cur_test"
+	cukinia_log "[$result] $__cukinia_cur_test"
 }
 
 # _cukinia_cmd: wrapper to any command

--- a/cukinia.conf.sample
+++ b/cukinia.conf.sample
@@ -1,3 +1,5 @@
+logging prefix "cukinia: "
+
 cukinia_user www-data
 cukinia_user mysql
 cukinia_process udchcpd


### PR DESCRIPTION
The 'logging' configuration statement is added, which allows configuring
the logging prefix. The original "cukinia:" log prefix can still be
enabled with this statement.