### PR TITLE
cukinia_mount: add filesystem type check

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A cukinia config file supports the following statements:
 * ``cukinia_http_request <url>``: Validates that url returns a 200 code
 * ``cukinia_cmd <command>``: Validates that arbitrary command returns true
 * ``cukinia_listen4 <proto> <port>``: Validates that tcp/udp port is open locally
-* ``cukinia_mount <source> <mount point> [options]``: Validate the
+* ``cukinia_mount <source> <mount point> [fstype] [options]``: Validate the
   presence of a mount on the system
 * ``cukinia_symlink <link> <target>``: Validate the target of a symlink
 * ``not``: Can prefix any test to invert the issue it will produce
@@ -85,8 +85,9 @@ as "Checking webapp" cukinia_http_request http://localhost:8080/sanitycheck
 # Run executable tests for myapp1
 cukinia_run_dir /etc/cukinia/myapp1.d/
 
-# Check for root mounting point on / in read write mode
-cukinia_mount sysfs /sys rw
+# Check for misc. mount points
+cukinia_mount sysfs /sys
+cukinia_mount /dev/sda1 /boot ext4 rw sync
 
 # Check for ssh and dns servers
 cukinia_listen4 tcp 22

--- a/cukinia
+++ b/cukinia
@@ -307,23 +307,33 @@ _cukinia_listen4()
 # _cukinia_mount: check for a specific mount point
 # arg1: the device
 # arg2: the mountpoint
+# arg3: (optional) the filesystem type (eg. ext4), or "any"
 # arg@: (optional) a list of options to look for
 _cukinia_mount()
 {
 	local device="$1"
 	local mountpoint="$2"
 	shift 2
+	local fstype="$1"; shift
 	local options="$*"
 	local found=0
 	local result
 
-	_cukinia_prepare "Checking mount: $device on $mountpoint with ${options:-any} options"
+	_cukinia_prepare "Checking mount: $device on $mountpoint type ${fstype:-any} (${options:-any})"
 
-	result=$(awk ' $1=="'$device'" && $2=="'$mountpoint'" { print $4 }' /proc/mounts | uniq)
+	# use fstype as an awk regex if present
+	if [ "$fstype" = "any" ] || [ -z "$fstype" ]; then
+		fstype=".*"
+	fi
+
+	result=$(awk '
+		$1 == "'$device'" && $2 == "'$mountpoint'" && $3 ~ /^'$fstype'$/ {
+			print $4;
+		}' /proc/mounts | uniq)
 
 	[ -n "$result" ] || return 1
 
-	# ensure all mount options are set
+	# ensure all expected mount options are set
 	for term in $options; do
 		if echo "$result" | grep -qw "$term"; then
 			found=$((found + 1))


### PR DESCRIPTION
The cukinia_mount function can now test for the filesystem type. If the
filesystem type is "any" or empty, any value will pass the test.