### PR TITLE
Fix example for mount detection

### DIFF
--- a/cukinia.conf.sample
+++ b/cukinia.conf.sample
@@ -8,7 +8,7 @@ cukinia_process Xorg
 cukinia_process nginx www-data
 cukinia_python_pkg math
 cukinia_http_request www.google.com
-cukinia_mount sysfs /sys rw
+cukinia_mount sysfs /sys sysfs rw
 cukinia_symlink /etc/network/interfaces /tmp/interfaces
 
 


### PR DESCRIPTION
`cukinia_mount sysfs /sys rw` doesn't work anymore as it think `rw` is the filesystem type. Explicitly giving the type fixes it.