### PR TITLE
cukinia: fix cukinia_symlink test

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -262,7 +262,7 @@ _cukinia_symlink()
 	local link="$1"
 	local target="$2"
 	_cukinia_prepare "Checking link \"$link\" points to \"$target\""
-	[ "$(readlink "$link")" = "$target" ] && return 0 || return 1
+	[ "$(readlink -f "$link")" = "$target" ] && return 0 || return 1
 }
 
 # _cukinia_listen4: check for a locally bound ipv4 port


### PR DESCRIPTION
The readlink command returns only the basename of a path if the link
points to a file or directory within the same directory. The test needs
to use the `-f` parameter to canonicalize the resolved link so that it
includes the complete path.