### PR TITLE
improve csv output: omit pretty print

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -144,6 +144,8 @@ cukinia_log()
 	csv)
 		case "$result" in
 		PASS|FAIL)
+			# Escape single quotes in test message to avoid commas detection
+			message=$(sed -e "s/'/\\\'/g" <<< "$message")
 			echo "'$message',$result" >>"$__log_file"
 			;;
 		*)

--- a/cukinia
+++ b/cukinia
@@ -142,10 +142,13 @@ cukinia_log()
 
 	case "$__log_format" in
 	csv)
-		if [ -n "$result" ]; then
-			# Escape single quotes in test message to avoid commas detection
-			echo "'${1/\'/\\\'}',$2" >>"$__log_file"
-		fi
+		case "$result" in
+		PASS|FAIL)
+			echo "'$message',$result" >>"$__log_file"
+			;;
+		*)
+			;;
+		esac
 		;;
 	*)
 		echo "${__log_pfx}$*" >>"$__log_file"


### PR DESCRIPTION
The csv output let non significant lines pass. this patch whitelists
specifically the results of tests (e.g PASS and FAIL lines).