### PR TITLE
overwrite existing output file without headers

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -84,6 +84,8 @@ case "$__log_format" in
 csv)
 	if [ -z "$__no_header" ]; then
 		echo "TEST MESSAGE, RESULT" >"$__log_file"
+	else
+		: >"$__log_file"
 	fi
 	;;
 *)


### PR DESCRIPTION
The --no-header option can be used to omit the optional CSV headers.
This commit fixes an issue when using both the --no-header and -o
options where Cukinia would not truncate the output file if it already
exists.