### PR TITLE
cukinia: add ver2int function

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -193,6 +193,18 @@ cukinia_log()
 	esac
 }
 
+ver2int() {                                                                     
+    	local IFS=.                                                                 
+	local version_str=$1                                                        
+	local res=0                                                                 
+	local fac=16                                                                
+	for v in $version_str; do                                                   
+        	res=$((res + $v << $fac))                                               
+		fac=$((fac / 2))                                                        
+    	done                                                                        
+	echo $res                                                                   
+} 
+
 # run the test and its context
 # arg1..n: command to run and their arguments
 cukinia_runner()


### PR DESCRIPTION
Add ver2int function to calculate an int based on a string version
(a.b.c). This function can then be used in cukinia to compare
versions.

For instance:
as test_ko cukinia_test $(ver2int 1.2.3) -gt $(ver2int 2.4.0)
as test_ok cukinia_test $(ver2int 2.4.1) -gt $(ver2int 2.4.0)