### PR TITLE
cukinia: add ver2int function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A cukinia config file supports the following statements:
 * ``cukinia_conf_include <files>``: Includes files as additional config files
 * ``cukinia_run_dir <directory>``: Runs all executables in directory as individual tests
 * ``cukinia_log <message>``: Logs message to stdout
+* ``_ver2int <version``: Convert version string to int, for comparison with cukinia_test
 
 ### Logging customization
 

--- a/cukinia
+++ b/cukinia
@@ -602,6 +602,17 @@ _cukinia_run_dir()
 	return $ret
 }
 
+# version to integer string utility
+# useful to do version compatibility checks
+# arg1: a dotted integer version string (semver style)
+_ver2int() {
+	echo "$1" | awk '{
+	   split($1, version_a, ".");
+	   print version_a[1] * 10^12 + version_a[2] * 10^8 +
+	   	 version_a[3] * 1^4 + version_a[4];
+	}'
+}
+
 # Template generic cukinia_* functions
 for func in $GENERIC_FUNCTS; do
 	eval "$(cat <<EOF


### PR DESCRIPTION
Add ver2int function to calculate an int based on a string version
(a.b.c). This function can then be used in cukinia to compare
versions.

For instance:
as test_ko cukinia_test $(_ver2int 1.2.3) -gt $(_ver2int 2.4.0)
as test_ok cukinia_test $(_ver2int 2.4.1) -gt $(_ver2int 2.4.0)