### PR TITLE
cukinia: consider name length for _cukinia_process

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -376,7 +376,7 @@ _cukinia_process()
 	# loop in /proc to get process name and optionally process owner
 	for status in /proc/[0-9]*/status; do
 		# check by process name
-		[ "$(grep Name "$status" | cut -f 2)" = "$pname" ] || continue
+		[ "$(grep Name "$status" | cut -f 2)" = "$(echo "$pname" | cut -c1-15)" ] || continue
 
 		# check optional process owner
 		if [ -z "$puser" ] || [ "$(grep Uid "$status" | cut -f 2)" = "$puser_uid" ]; then


### PR DESCRIPTION
In /proc, process name maximal length is 15. We need thus to cut the
argument of _cukinia_process if it exceeds 15 characters.