### PR TITLE
cukinia: ensure that only provided arguments are shifted

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -563,8 +563,8 @@ _cukinia_mount()
 {
 	local device="$1"
 	local mountpoint="$2"
-	shift 2
-	local fstype="$1"; shift
+	shift $#
+	local fstype="$1"; shift $#
 	local options="$*"
 	local found=0
 	local result


### PR DESCRIPTION
"shift" builtin in dash does not support shifting more than the number
of arguments supplied in the argument list. This situation raise a
fatal error that is caught by the shell which eventually interrupts
the script execution.

Only shift up to "$#" arguments to prevent unexpected script endings
when using dash.