### PR TITLE
cukinia: add kernel config check in boot partition

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -445,12 +445,13 @@ _cukinia_kmod()
 _cukinia_kconf()
 {
 	local ikconfig="/proc/config.gz"
+	local bootconfig="/boot/config-$(uname -r)"
 	local kconf="$1"
 	local kset="$2"
 	local line=""
 
-	if [ ! -e "$ikconfig" ]; then
-		_cukinia_prepare "cukinia_kconf: $ikconfig (CONFIG_IKCONFIG_PROC=y) is ${__not:+NOT }required"
+	if [ ! -e "$ikconfig" ] && [ ! -e "$bootconfig" ]; then
+		_cukinia_prepare "cukinia_kconf: $ikconfig (CONFIG_IKCONFIG_PROC=y) or $bootconfig is ${__not:+NOT }required"
 		return 1
 	fi
 
@@ -465,7 +466,11 @@ _cukinia_kconf()
 		;;
 	esac
 
-	zcat /proc/config.gz | grep -q "^$line"
+	if [ ! -e "$ikconfig" ]; then
+		cat $bootconfig | grep -q "^$line"
+	else
+		zcat /proc/config.gz | grep -q "^$line"
+	fi
 }
 
 # _cukinia_kversion: check if running kernel version is MAJ.MIN


### PR DESCRIPTION
cukinia_kconf only check kernel configuration in /proc/config.gz. The kernel configuration can also be stored in boot partition. Add in the cukinia_kconf function, the kernel configuration check in boot partition.