### PR TITLE
cukinia: accept space char in suite name

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -929,7 +929,7 @@ _junitxml_end()
 # arg1: output file for the <testsuite> block
 _junitxml_end_suite()
 {
-	local name=$__suite_name
+	local name="$__suite_name"
 	local outfile="$1"
 	local timestamp
 	local failures
@@ -967,8 +967,8 @@ _junitxml_end_suite()
 	cat >>$outfile <<EOF
   <testsuite name="$name" package="$name" errors="$errors" tests="$tests" failures="$failures" timestamp="$timestamp" time="$seconds">
 EOF
-	cat $__logfile_tmp.$name >>$outfile
-	rm -f $__logfile_tmp.$name
+	cat "$__logfile_tmp.$name" >>$outfile
+	rm -f "$__logfile_tmp.$name"
 	echo "  </testsuite>" >>$outfile
 }
 
@@ -979,7 +979,7 @@ _junitxml_add_suite()
 	local name="$1"
 
 	# strip the name from any fancy character
-	name="$(echo $name | sed -e 's/[^a-zA-Z0-9_]//g')"
+	name="$(echo $name | sed -e 's/[^a-zA-Z0-9_ ]//g')"
 
 	if [ -z "$name" ]; then
 		return 1


### PR DESCRIPTION
Previous implementation of cukinia get rid of all spaces written in a suite name.
That could be a problem when displaying long and complex test suite name.

This commit allow spaces in suite name and correct the behavior of the junit logfile name accordingly.