### PR TITLE
cukinia: log verbose stdout/err in cukinia_runner

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -248,7 +248,11 @@ cukinia_runner()
 	local ret
 
 	if [ -n "$__verbose" ]; then
-	       "$@"
+		if [ "$__log_format" = "junitxml" ]; then
+			"$@" 1>$__stdout_tmp 2>$__stderr_tmp
+		else
+			"$@"
+		fi
 	else
 		"$@" >/dev/null 2>&1
 	fi
@@ -1147,11 +1151,7 @@ for func in $GENERIC_FUNCTS; do
 	eval "$(cat <<EOF
 cukinia_$func()
 {
-      if [ "$__log_format" = "junitxml" ]; then
-          cukinia_runner _cukinia_$func "\$@" 1>$__stdout_tmp 2>$__stderr_tmp
-      else
-          cukinia_runner _cukinia_$func "\$@"
-      fi
+	cukinia_runner _cukinia_$func "\$@"
 }
 EOF
 )"


### PR DESCRIPTION
This creates stdout/err log files for "verbose cukinia_run_dir" to be logged in the junitxml file.

After this change this was tested with a config file including:
`verbose cukinia_run_dir /opt/cukinia/tests.d`

/opt/cukinai/tests.d/test1:
```
#!/bin/sh -e

echo "foo"
echo "bar" >&2

exit 0
```
`cukinia -f junitxml -o /output.xml /opt/cukinia/cukinia.conf` generates:

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="default" package="default" errors="0" tests="1" failures="0" timestamp="2023-08-15T12:37:20" time="0">
    <testcase classname="cukinia" name="External: /opt/cukinia/tests.d/test1" time="0">
      <system-err><![CDATA[bar]]></system-err>
      <system-out><![CDATA[foo]]></system-out>
    </testcase>
  </testsuite>
</testsuites>
```
