### PR TITLE
cukinia: filter junitxml output to only include valid xml 1.0 chars

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -1055,13 +1055,13 @@ EOF
 
 	if [ -s "$__stderr_tmp" ]; then
 		cat >>$logfile <<EOF
-      <system-err><![CDATA[$(cat $__stderr_tmp)]]></system-err>
+      <system-err><![CDATA[$(cat $__stderr_tmp | tr -dc [:print:])]]></system-err>
 EOF
 	fi
 
 	if [ -s "$__stdout_tmp" ]; then
 		cat >>$logfile <<EOF
-      <system-out><![CDATA[$(cat $__stdout_tmp)]]></system-out>
+      <system-out><![CDATA[$(cat $__stdout_tmp | tr -dc [:print:])]]></system-out>
 EOF
 	fi
 

--- a/tests/xml/validation/ascii.sh
+++ b/tests/xml/validation/ascii.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for i in $(seq 0 255); do
+    printf "\\$(printf '%03o' $i)"
+    >&2 printf "\\$(printf '%03o' $i)"
+done

--- a/tests/xml/validation/filtertest.sh
+++ b/tests/xml/validation/filtertest.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+echo -e '\x1b[0;93m[FOO]\x1b[0m'
+>&2 echo -e '\x1b[0;93m[FOO]\x1b[0m'

--- a/tests/xml/validation/random.sh
+++ b/tests/xml/validation/random.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cat /dev/urandom | dd bs=1M count=1
+cat /dev/urandom | >&2 dd bs=1M count=1

--- a/tests/xml/xml.conf
+++ b/tests/xml/xml.conf
@@ -1,0 +1,1 @@
+verbose cukinia_run_dir validation


### PR DESCRIPTION
In running some hardware tests that use cukinia_cmd/cukinia_run_dir I ran a script that included "btattach" output. This includes invalid chars in XML 1.0. Jenkins will refuses to parse the output file.

The exact btattach output can be reproduced with:
tests/unicode/filtertest.sh
```
#!/bin/sh -e

echo -e '\x1b[0;93m[CHG]\x1b[0m'
>&2 echo -e '\x1b[0;93m[CHG]\x1b[0m'
```

unicode.conf:
```
verbose cukinia_run_dir tests/unicode
```

run:
```
./cukinia -f junitxml -o output.xml unicode.conf && xmllint output.xml
```

This will return:
```
output.xml:5: parser error : Unregistered error message
      <system-err><![CDATA[[BAR]]]></system-err>
                           ^
output.xml:5: parser error : PCDATA invalid Char value 27
      <system-err><![CDATA[[BAR]]]></system-err>
                           ^
output.xml:5: parser error : PCDATA invalid Char value 27
      <system-err><![CDATA[[BAR]]]></system-err>
                                       ^
output.xml:5: parser error : Sequence ']]>' not allowed in content
      <system-err><![CDATA[[BAR]]]></system-err>
                                        ^
output.xml:6: parser error : Unregistered error message
      <system-out><![CDATA[[FOO]]]></system-out>
                           ^
output.xml:6: parser error : PCDATA invalid Char value 27
      <system-out><![CDATA[[FOO]]]></system-out>
                           ^
output.xml:6: parser error : PCDATA invalid Char value 27
      <system-out><![CDATA[[FOO]]]></system-out>
                                       ^
output.xml:6: parser error : Sequence ']]>' not allowed in content177
      <system-out><![CDATA[[FOO]]]></system-out>
```
Jenkins will refuse to parse this with:
```
org.dom4j.DocumentException: Error on line 11 of document  : An invalid XML character (Unicode: 0x1) was found in the CDATA section.
	at org.dom4j.io.SAXReader.read(SAXReader.java:511)
	at org.dom4j.io.SAXReader.read(SAXReader.java:392)
```

This commit uses tr to filter to only valid characters. I tested this with a few other examples:
Byte values 0-255:
```
#!/bin/bash

for i in $(seq 0 255); do
    printf "\\$(printf '%03o' $i)"
done
```
Random:
```
#!/bin/sh

dd bs=1M count=10 if=/dev/urandom
```

Both of these pass after adding the tr filter. The downside to this method is that it is overly aggressive. This will break unicode that otherwise might be valid in xml 1.0/junitxml, but I'm not sure how else to filter this more carefully in only busybox / sh otherwise. I'm curious if there are thoughts on any better way to handle this.

The other solution I see to this are just requiring the tests to limit their own output. I could certainly make my test script silent if it succeeds, but the most valuable output is probably when it fails in surprising ways where I might want to see the unexpected output.