### PR TITLE
cukinia_kprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A cukinia config file supports the following statements:
   symbol is set to given tristate value
 * ``cukinia_kversion <version>``: Validate kernel version (only check maj.min, e.g 5.14)
 * ``cukinia_process <pname> [user]``: Validates that process runs (optional user)
+* ``cukinia_kprocess <pname>``: Validates that kernel process runs
 * ``cukinia_python_pkg <pkg>``: Validates that Python package is installed
 * ``cukinia_test <expr>``: Validates that test(1) expression is true
 * ``cukinia_http_request <url>``: Validates that url returns a 200 code

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A cukinia config file supports the following statements:
   symbol is set to given tristate value
 * ``cukinia_kversion <version>``: Validate kernel version (only check maj.min, e.g 5.14)
 * ``cukinia_process <pname> [user]``: Validates that process runs (optional user)
-* ``cukinia_kprocess <pname>``: Validates that kernel process runs
+* ``cukinia_kthread <pname>``: Validates that kernel thread runs
 * ``cukinia_python_pkg <pkg>``: Validates that Python package is installed
 * ``cukinia_test <expr>``: Validates that test(1) expression is true
 * ``cukinia_http_request <url>``: Validates that url returns a 200 code

--- a/cukinia
+++ b/cukinia
@@ -31,7 +31,7 @@ GENERIC_FUNCTS='cmd
 		netif_has_ip
 		netif_is_up
 		process
-		kprocess
+		kthread
 		python_pkg
 		symlink
 		sysctl
@@ -566,18 +566,18 @@ _cukinia_process()
 	return 1
 }
 
-# cukinia_kprocess: checks if kernel process $pname runs
-# arg: $1: the kernel process name
-_cukinia_kprocess()
+# cukinia_kthread: checks if kernel thread $pname runs
+# arg: $1: the kernel thread name
+_cukinia_kthread()
 {
 	local pname="$1"
 	local procdir
 	local pid
 
-	_cukinia_prepare "Checking kernel process \"$pname\" ${__not:+NOT }running"
+	_cukinia_prepare "Checking kernel thread \"$pname\" ${__not:+NOT }running"
 
-	# scan /proc to get process name
-        # as some version of pidof do not look for kernel process, use pgrep with exact match
+	# scan /proc to get thread name
+        # as some version of pidof do not look for kernel thread, use pgrep with exact match
 	for pid in $(pgrep -x "$pname"); do
 		# check that it is a kernel threads
                 # null byte is removed from thread cmdline to avoid bash warning

--- a/cukinia
+++ b/cukinia
@@ -31,6 +31,7 @@ GENERIC_FUNCTS='cmd
 		netif_has_ip
 		netif_is_up
 		process
+		kprocess
 		python_pkg
 		symlink
 		sysctl
@@ -560,6 +561,27 @@ _cukinia_process()
 		# check process owner
 		owner_uid=$(awk '/^Uid:/ { print $2 }' < $procdir/status)
 		[ "$owner_uid" = "$puser_uid" ] && return 0
+	done
+
+	return 1
+}
+
+# cukinia_kprocess: checks if kernel process $pname runs
+# arg: $1: the kernel process name
+_cukinia_kprocess()
+{
+	local pname="$1"
+	local procdir
+	local pid
+
+	_cukinia_prepare "Checking kernel process \"$pname\" ${__not:+NOT }running"
+
+	# scan /proc to get process name
+        # as some version of pidof do not look for kernel process, use pgrep with exact match
+	for pid in $(pgrep -x "$pname"); do
+		# check that it is a kernel threads
+                # null byte is removed from thread cmdline to avoid bash warning
+		[ -z "$(tr -d '\0' < /proc/$pid/cmdline)" ] && return 0
 	done
 
 	return 1

--- a/cukinia
+++ b/cukinia
@@ -579,9 +579,9 @@ _cukinia_kthread()
 	# scan /proc to get thread name
         # as some version of pidof do not look for kernel thread, use pgrep with exact match
 	for pid in $(pgrep -x "$pname"); do
-		# check that it is a kernel threads
-                # null byte is removed from thread cmdline to avoid bash warning
-		[ -z "$(tr -d '\0' < /proc/$pid/cmdline)" ] && return 0
+		# check that it is a kernel thread
+		status_file=/proc/$pid/status
+		grep -q "Name" "$status_file" && ! grep -q "^VmSize" "$status_file" && return 0
 	done
 
 	return 1

--- a/tests/testcases.conf
+++ b/tests/testcases.conf
@@ -32,6 +32,12 @@ cukinia_process systemd root
 not cukinia_process systemd nonexistent
 not cukinia_process nosuchprocess
 
+section "cukinia_kprocess"
+
+cukinia_kprocess watchdogd
+not cukinia_kprocess systemd
+not cukinia_kprocess nosuchprocess
+
 section "cukinia_http_request"
 
 as "HTTP 200 on localhost:631 (cups)" cukinia_http_request http://localhost:631/

--- a/tests/testcases.conf
+++ b/tests/testcases.conf
@@ -32,11 +32,11 @@ cukinia_process systemd root
 not cukinia_process systemd nonexistent
 not cukinia_process nosuchprocess
 
-section "cukinia_kprocess"
+section "cukinia_kthread"
 
-cukinia_kprocess watchdogd
-not cukinia_kprocess systemd
-not cukinia_kprocess nosuchprocess
+cukinia_kthread watchdogd
+not cukinia_kthread systemd
+not cukinia_kthread nosuchprocess
 
 section "cukinia_http_request"
 


### PR DESCRIPTION
As explained in issue #59, `cukinia_process` allows checking that a user process is running, however it explicitly doesn't allow testing kernel processes:
```shell
        # skip kernel threads
        [ -x $procdir/exe ] || continue
```

It can be legitimate to verify that some key kernel threads are running, for instance `[watchdogd]`.

This pull-request implements the suggested `cukinia_kprocess` command.