### PR TITLE
cukinia_i2c: check driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A cukinia config file supports the following statements:
 * ``cukinia_symlink <link> <target>``: Validate the target of a symlink
 * ``cukinia_systemd_failed``: Raise a failure if a systemd unit is in failed state
 * ``cukinia_systemd_unit <unit>``: Validate systemd unit is active
-* ``cukinia_i2c <bus_number> [device_address]``: This checks i2c bus or (optional) device
+* ``cukinia_i2c <bus_number> [device_address] [driver_name]``: This checks i2c bus or (optional) device, and (optionally) verifies it uses the indicated driver
 * ``cukinia_gpio_libgpiod -i [input_pins] -l [output_low_pins] -h [output_high_pins]
   -g [gpiochip](default:gpiochip0)``: Validate the gpio configuration via libgpiod
   (ex: cukinia_gpio_libgpiod -i "0 3 4" -l "10" -h "2 50" -g gpiochip1)

--- a/cukinia
+++ b/cukinia
@@ -704,15 +704,18 @@ _cukinia_mount()
 
 # _cukinia_i2c: Check if i2c device exists
 # Optional: Check of a device address
+# Optional: Check the device uses the correct driver
 # arg1: the bus number
 # arg2: (optional) the device address
+# arg3: (optional) the device driver name
 _cukinia_i2c()
 {
 	local bus_number="$1"
 	local device_address="$2"
+	local driver_name="$3"
 	local ret
 
-	_cukinia_prepare "Checking if i2c-$bus_number${device_address:+-$device_address} exists"
+	_cukinia_prepare "Checking if i2c-$bus_number${device_address:+-$device_address} exists${driver_name:+ and is $driver_name}"
 
 	if [ ! -d /sys/bus/i2c/devices/i2c-"$bus_number" ]; then
 		return 1
@@ -730,7 +733,22 @@ _cukinia_i2c()
 	device_address=${device_address#0x}
 	i2cdetect -y "$bus_number" 0x"$device_address" 0x"$device_address" | cut -d ':' -f2 | grep -E "$device_address|UU"
 	ret=$?
-	return $ret
+	if [ $ret -ne 0 ]; then
+		return $ret
+	fi
+
+	if [ -z "$driver_name" ]; then
+		return 0
+	fi
+
+	local device_path=$bus_number-$(printf '%0'4'd' $device_address)
+	local link=/sys/bus/i2c/devices/$device_path/driver
+	local target=/sys/bus/i2c/drivers/$driver_name
+
+	# fail on non-symlinks
+	[ -L "$link" ] || return 1
+
+	[ "$(readlink -f "$link")" = "$(readlink -f "$target")" ] && return 0 || return 1
 }
 
 # _cukinia_gpio_libgpiod: Check gpio configuration via libgpiod


### PR DESCRIPTION
This PR extends the `cukinia_i2c` test to check that an I2C device correctly uses the indicated driver. This enables to test an I2C device in a single line, without needing an additional symlink test.

For example, to test that the device at address 0x49 on i2c bus 3 is a da9062:
```
cukinia_i2c 3 49 da9062
```

Instead of:
```
cukinia_i2c 3 49
cukinia_symlink /sys/bus/i2c/devices/3-0049/driver /sys/bus/i2c/drivers/da9062
```