### PR TITLE
cukinia: add test id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A cukinia config file supports the following statements:
   ``[!]`` is appended to the default test description)
 * ``verbose``: Can prefix any test to preserve stdout/stderr
 * ``as <string>``: Can prefix any test to change its textual description
+* ``id <string>``: Can prefix any test to add a test id in the different outputs
 
 ### Condition statements
 
@@ -161,6 +162,9 @@ cukinia_listen4 udp 53
 
 # Check the link interfaces point to /tmp/interfaces
 cukinia_symlink /etc/network/interfaces /tmp/interfaces
+
+# Add a id linked to the test
+id "SWR_001" as "Checking systemd units" cukinia_systemd_failed
 
 # End
 cukinia_log "ran $cukinia_tests tests, $cukinia_failures failures"

--- a/cukinia
+++ b/cukinia
@@ -280,6 +280,7 @@ cukinia_runner()
 		__not="pass"
 	elif [ -n "$__skip_condition" ]; then
 		_cukinia_result SKIP
+		cukinia_skip=$((cukinia_skip + 1))
 		return
 	fi
 
@@ -1103,10 +1104,12 @@ _junitxml_end_suite()
 	# cleanup suite-specific variables
 	timestamp=$__suite_timestamp
 	failures=$__suite_failures
+	skipped=$__suite_skipped
 	errors=$__suite_errors
 	tests=$__suite_tests
 	unset __suite_timestamp
 	unset __suite_failures
+	unset __suite_skipped
 	unset __suite_errors
 	unset __suite_tests
 	unset __suite_name
@@ -1122,7 +1125,7 @@ _junitxml_end_suite()
 
 	# append the whole testsuite block to the outfile
 	cat >>$outfile <<EOF
-  <testsuite name="$name" package="$name" errors="$errors" tests="$tests" id="$__suite_id" hostname="$hostname" failures="$failures" timestamp="$timestamp" time="$seconds">
+  <testsuite name="$name" package="$name" errors="$errors" tests="$tests" id="$__suite_id" hostname="$hostname" failures="$failures" timestamp="$timestamp" skipped="$skipped" time="$seconds">
     <properties>
     </properties>
 EOF
@@ -1172,6 +1175,7 @@ _junitxml_add_suite()
 	__suite_name="$name"
 	__suite_tests=0
 	__suite_errors=0
+	__suite_skipped=0
 	__suite_failures=0
 	__suite_timestamp=$(date +%Y-%m-%dT%H:%M:%S)
 }
@@ -1210,11 +1214,17 @@ _junitxml_add_case()
     <testcase classname="${__log_class:-cukinia}" name="$name" time="0">
 EOF
 
-	if [ "$result" != "PASS" ]; then
+	if [ "$result" == "FAIL" ]; then
 		__suite_failures=$((__suite_failures + 1))
 
 		cat >>"$logfile" <<EOF
       <failure type="unit-test" message="failed"><![CDATA[$message: FAIL]]></failure>
+EOF
+	elif [ "$result" == "SKIP" ]; then
+		__suite_skipped=$((__suite_skipped + 1))
+
+		cat >>"$logfile" <<EOF
+      <skipped message="skipped"><![CDATA[$message: SKIP]]></skipped>
 EOF
 	fi
 
@@ -1323,6 +1333,7 @@ done
 
 cukinia_tests=0
 cukinia_failures=0
+cukinia_skip=0
 cukinia_conf_include "$CUKINIA_CONF"
 
 # Finish logging

--- a/cukinia
+++ b/cukinia
@@ -138,7 +138,7 @@ cukinia_epoch=$(date +%s)
 case "$__log_format" in
 csv)
 	if [ -z "$__no_header" ]; then
-		echo "TEST MESSAGE, RESULT, TEST CLASS, TEST SUITE" >"$__logfile_tmp"
+		echo "TEST MESSAGE, RESULT, TEST CLASS, TEST SUITE, TEST ID" >"$__logfile_tmp"
 	else
 		: >"$__logfile_tmp"
 	fi
@@ -240,7 +240,7 @@ cukinia_log()
 	csv)
 		if _should_log; then
 			message=$(echo $message | sed -e "s/'/\\'/g") # ' -> \'
-			echo "'$message',$result,$__log_class,$__suite_name" >>"$__logfile_tmp"
+			echo "'$message',$result,$__log_class,$__suite_name,$__test_id" >>"$__logfile_tmp"
 		fi
 		;;
 
@@ -315,6 +315,20 @@ cukinia_run_dir()
 		[ -d "$dir" ] || continue
 		_cukinia_run_dir "$dir"
 	done
+}
+
+# id: add a test identifier to easily track it
+# arg1: id name
+# arg2..: command
+id()
+{
+	local ret=0
+	__test_id="$1"; shift
+
+	"$@" || ret=1
+	unset __test_id
+
+	return $ret
 }
 
 # as: change the description of what follows
@@ -442,7 +456,7 @@ _cukinia_result()
 		local suffix=" [$(_colorize yellow2 "unmet condition")]"
 	fi
 
-	cukinia_log "[$result] ${__cukinia_cur_test}${suffix}"
+	cukinia_log "[$result] "${__test_id:+ ${__test_id} --}" ${__cukinia_cur_test}${suffix}"
 }
 
 # _cukinia_cmd: wrapper to any command
@@ -1197,6 +1211,14 @@ EOF
 	if [ -s "$__stdout_tmp" ]; then
 		cat >>"$logfile" <<EOF
       <system-out><![CDATA[$(cat $__stdout_tmp | tr -dc [:print:])]]></system-out>
+EOF
+	fi
+
+	if [ -n "$__test_id" ]; then
+		cat >>"$logfile" <<EOF
+      <properties>
+        <property name="cukinia.id" value="$__test_id"/>
+      </properties>
 EOF
 	fi
 

--- a/cukinia
+++ b/cukinia
@@ -1232,12 +1232,14 @@ EOF
 		cat >>"$logfile" <<EOF
       <system-err><![CDATA[$(cat $__stderr_tmp | tr -dc [:print:])]]></system-err>
 EOF
+	> $__stderr_tmp
 	fi
 
 	if [ -s "$__stdout_tmp" ]; then
 		cat >>"$logfile" <<EOF
       <system-out><![CDATA[$(cat $__stdout_tmp | tr -dc [:print:])]]></system-out>
 EOF
+	> $__stdout_tmp
 	fi
 
 	if [ -n "$__test_id" ]; then

--- a/cukinia
+++ b/cukinia
@@ -43,6 +43,9 @@ GENERIC_FUNCTS='cmd
 # By default log to stdout
 __log_file="/dev/stdout"
 
+# Initialize suite id
+__suite_id=0
+
 # Ensure cleanup of temporary files
 trap cleanup 0
 
@@ -1108,6 +1111,7 @@ _junitxml_end_suite()
 	unset __suite_tests
 	unset __suite_name
 
+	hostname=$(hostname)
 
 	# derive suite duration from the timestamp
 	# note: busybox 1.27 'date' may choke on the iso8601 T format
@@ -1118,11 +1122,23 @@ _junitxml_end_suite()
 
 	# append the whole testsuite block to the outfile
 	cat >>$outfile <<EOF
-  <testsuite name="$name" package="$name" errors="$errors" tests="$tests" failures="$failures" timestamp="$timestamp" time="$seconds">
+  <testsuite name="$name" package="$name" errors="$errors" tests="$tests" id="$__suite_id" hostname="$hostname" failures="$failures" timestamp="$timestamp" time="$seconds">
+    <properties>
+    </properties>
 EOF
 	cat "$__logfile_tmp.$name" >>$outfile
 	rm -f "$__logfile_tmp.$name"
+
+	cat >>"$outfile" <<EOF
+      <system-out><![CDATA[]]></system-out>
+EOF
+
+	cat >>"$outfile" <<EOF
+      <system-err><![CDATA[]]></system-err>
+EOF
+
 	echo "  </testsuite>" >>$outfile
+	__suite_id=$((__suite_id + 1))
 }
 
 # Start a new <testsuite> section

--- a/tests/testcases.conf
+++ b/tests/testcases.conf
@@ -193,4 +193,4 @@ id "SWR_003" cukinia_cmd false
 
 section "tests/failures counters"
 
-cukinia_log "ran $cukinia_tests tests, $(_colorize cyan "$cukinia_failures failed")"
+cukinia_log "ran $cukinia_tests tests, $(_colorize cyan "$cukinia_failures failed"), $(_colorize yellow2 "$cukinia_skip skipped")"

--- a/tests/testcases.conf
+++ b/tests/testcases.conf
@@ -175,6 +175,10 @@ for color in red green blue cyan yellow gray purple; do
 	cukinia_log "* _colorize $(_colorize ${color}2 ${color}2)"
 done
 
+section "Tests with id"
+id "SWR_001" cukinia_cmd true
+id "SWR_002" as "Running cukinia command with as and id" cukinia_cmd true
+
 section "failure detection (must all FAIL)"
 
 cukinia_run_dir ./exec.fail.d
@@ -185,6 +189,7 @@ cukinia_process nosuchprocess
 cukinia_python_pkg nosuchpackage
 cukinia_symlink /dev/zero /dev/null
 cukinia_systemd_unit nosuchunit.service
+id "SWR_003" cukinia_cmd false
 
 section "tests/failures counters"
 

--- a/tests/xml/JUnit.xsd
+++ b/tests/xml/JUnit.xsd
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	 elementFormDefault="qualified"
+	 attributeFormDefault="unqualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+	</xs:annotation>
+	<xs:element name="testsuite" type="testsuite"/>
+	<xs:simpleType name="ISO8601_DATETIME_PATTERN">
+		<xs:restriction base="xs:dateTime">
+			<xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="testsuites">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="testsuite">
+								<xs:attribute name="package" type="xs:token" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="id" type="xs:int" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="testsuite">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains the results of executing a testsuite</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="properties">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="name" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:token">
+											<xs:minLength value="1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="value" type="xs:string" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence minOccurs="0" maxOccurs="4">
+						<xs:choice minOccurs="0">
+							<xs:element name="skipped" minOccurs="0" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation xml:lang="en">Indicates that the test was skipped.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="pre-string">
+											<xs:attribute name="message" type="xs:string">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">The message specifying why the test case was skipped</xs:documentation>
+												</xs:annotation>
+											</xs:attribute>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="error" minOccurs="0" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="pre-string">
+											<xs:attribute name="message" type="xs:string">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+												</xs:annotation>
+											</xs:attribute>
+											<xs:attribute name="type" type="xs:string" use="required">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+												</xs:annotation>
+											</xs:attribute>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="failure">
+								<xs:annotation>
+									<xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="pre-string">
+											<xs:attribute name="message" type="xs:string">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+												</xs:annotation>
+											</xs:attribute>
+											<xs:attribute name="type" type="xs:string" use="required">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+												</xs:annotation>
+											</xs:attribute>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+						</xs:choice>
+						<xs:sequence minOccurs="0">
+							<xs:element name="properties">
+								<xs:annotation>
+									<xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:attribute name="name" use="required">
+													<xs:simpleType>
+														<xs:restriction base="xs:token">
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:attribute>
+												<xs:attribute name="value" type="xs:string" use="required"/>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:sequence minOccurs="0">
+							<xs:element name="system-out">
+								<xs:annotation>
+									<xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="pre-string">
+										<xs:whiteSpace value="preserve"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+						<xs:sequence minOccurs="0">
+							<xs:element name="system-err">
+								<xs:annotation>
+									<xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="pre-string">
+										<xs:whiteSpace value="preserve"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+					<xs:attribute name="name" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="classname" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="time" type="xs:decimal" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="system-out">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="system-err">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="hostname" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="tests" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="failures" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="errors" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="skipped" type="xs:int" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of ignored or skipped tests in the suite.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="time" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="pre-string">
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/tests/xml/lint.conf
+++ b/tests/xml/lint.conf
@@ -1,0 +1,7 @@
+cd ../
+../cukinia -f junitxml -o xml/test.xml testcases.conf
+cd - > /dev/null
+
+verbose cukinia_cmd xmllint --noout --schema JUnit.xsd test.xml
+
+rm -f test.xml


### PR DESCRIPTION
Add the possibility to add a test id before the test. This could be use to easily track the tests.
This id is then also added/displayed in the different outputs.