### PR TITLE
add retry statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ when "arch_is_arm64" \
   unless "on_eval_board" \
     cukinia_kmod some_driver 
 ```
+* `on <test_result> <statement>`: Can execute a statemement conditionally to test result
+For each test result some statements can be executed:
+    * `retry <count> [after <interval>]`: retry the test `count` times after
+    optional `interval` second(s), month(m), hour(h) or day(d) between each attempt (default to 0 second).
+    The `count` is the number of retry attempts, the first attempt is not counted.
+    Then if count is 3, the test will be executed 4 times if the condition is not met.
+        examples:
+        ``` shell
+        on success retry 3 after 2s cukinia_systemd_unit some_unit
+        on failure retry 3 cukinia_systemd_unit some_unit
+        ```
 
 ### Utility statements
 

--- a/cukinia
+++ b/cukinia
@@ -259,11 +259,27 @@ cukinia_log()
 	esac
 }
 
+# Retry current cukinia test with optionnal delay
+# arg1..n: cukinia test arguments
+_cukinia_retry()
+{
+	local arguments="$@"
+
+	echo >&2 "Retry \"$__cukinia_cur_test\" in ${__wait_time:-0s}"
+	__retry=$((__retry-1))
+	sleep ${__wait_time:-0}
+	cukinia_runner $arguments
+
+	return $ret
+}
+
 # run the test and its context
 # arg1..n: command to run and their arguments
 cukinia_runner()
 {
 	local ret
+	local result
+	local arguments="$@"
 
 	if [ -n "$__verbose" ]; then
 		if [ "$__log_format" = "junitxml" ]; then
@@ -286,25 +302,45 @@ cukinia_runner()
 
 	case "$__not..$ret" in
 	pass..*)
-		_cukinia_result PASS
+		result=PASS
 		;;
 	1..0)
-		_cukinia_result FAIL
-		cukinia_failures=$((cukinia_failures + 1))
+		result=FAIL
 		;;
 	1..*)
-		_cukinia_result PASS
+		result=PASS
 		;;
 	..0)
-		_cukinia_result PASS
+		result=PASS
 		;;
 	..*)
-		_cukinia_result FAIL
-		cukinia_failures=$((cukinia_failures + 1))
+		result=FAIL
 		;;
 	esac
 
-	cukinia_tests=$((cukinia_tests + 1))
+	case "$result" in
+	PASS)
+		if [ "${__on_success}" ]; then
+			if [ "${__retry}" != 0 ]; then
+				_cukinia_retry $arguments
+				return $ret
+			fi
+		fi
+		cukinia_tests=$((cukinia_tests + 1))
+		_cukinia_result PASS
+		;;
+	FAIL)
+		if [ "${__on_failure}" ]; then
+			if [ "${__retry}" != 0 ]; then
+				_cukinia_retry $arguments
+				return $ret
+			fi
+		fi
+		cukinia_failures=$((cukinia_failures + 1))
+		cukinia_tests=$((cukinia_tests + 1))
+		_cukinia_result FAIL
+		;;
+	esac
 
 	return $ret
 }
@@ -406,6 +442,55 @@ when()
 {
 	local condition="$1"; shift
 	_condition_run "$condition" "$@"
+}
+
+# on: execute statement conditionally to test result
+# arg1: Test result
+# arg2..: command
+on()
+{
+	local test_result="$1"; shift
+	local ret=0
+
+	if [ "$test_result" = "failure" ]; then
+		__on_failure=1
+	elif [ "$test_result" = "success" ]; then
+		__on_success=1
+	fi
+
+	"$@" || ret=1
+	unset __on_failure
+	unset __on_success
+
+	return $ret
+}
+
+# retry: Set a number of retry
+# arg1: the number of retry
+# arg2..: command
+retry()
+{
+	local ret=0
+	__retry="$1"; shift
+
+	"$@" || ret=1
+	unset __retry
+
+	return $ret
+}
+
+# after: Set wait between each retry
+# arg1: the wait time between each retry (in seconds)
+# arg2..: command
+after()
+{
+	local ret=0
+	__wait_time="$1"; shift
+
+	"$@" || ret=1
+	unset __wait_time
+
+	return $ret
 }
 
 # _cukinia_python_pkg: try to import the python package

--- a/tests/scripts/flaky.sh
+++ b/tests/scripts/flaky.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Get the current second number
+second=$(date +%S)
+
+# Check if the second number is even
+if [ $((second % 2)) -eq 0 ]; then
+    exit 0  # Success
+else
+    exit 1  # Failure
+fi

--- a/tests/testcases.conf
+++ b/tests/testcases.conf
@@ -185,6 +185,19 @@ section "Tests with id"
 id "SWR_001" cukinia_cmd true
 id "SWR_002" as "Running cukinia command with as and id" cukinia_cmd true
 
+section "on failure retry"
+on failure retry 3 after 1s as "Should fail and retry 3 times"  cukinia_cmd /bin/false
+on failure retry 3 after 1s as "Should pass (no retries)" cukinia_cmd /bin/true
+when "false" on failure retry 3 after 1s as "Should skip (no retries)" cukinia_cmd /bin/false
+when "true" on failure retry 2 as "Should fail and retry 2 times" cukinia_cmd /bin/false
+on failure retry 1 after 1s as "Will pass on first try, or on retry" cukinia_cmd ./scripts/flaky.sh
+
+section "on success retry"
+on success retry 2 after 1s as "Should fail (no retries)" cukinia_cmd /bin/false
+on success retry 2 as "Should pass and retry 2 times" cukinia_cmd /bin/true
+when "false" on success retry 2 as "Should skip (no retries)" cukinia_cmd /bin/true
+when "true" on success retry 1 after 2s as "Should pass and retry 1 time" cukinia_cmd /bin/true
+
 section "failure detection (must all FAIL)"
 
 cukinia_run_dir ./exec.fail.d


### PR DESCRIPTION
This commit adds a new statement `retry` that allows to retry a test a given number of times with a given interval between each attempt before failing.

The `retry` statement is used as follows:
```
retry <count> <interval> <command>
```

When this statement is used, an output message is displayed when the test is retried.
For example for the test:
```
retry 2 1 as "Should fail after 2 tries" cukinia_cmd /bin/false
```
 Cukinia will display after the first try:
```
  Retry "Should fail after 2 tries" in 1 seconds
```
After the second try, the classic cukinia fail output will be shown.