### PR TITLE
cukinia_imx6_fuse: add a new cukinia function to check i.MX6 fuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ A cukinia config file supports the following statements:
 * ``cukinia_systemd_failed``: Raise a failure if a systemd unit is in failed state
 * ``cukinia_systemd_unit <unit>``: Validate systemd unit is active
 * ``cukinia_i2c <bus_number> [device_address] [driver_name]``: This checks i2c bus or (optional) device, and (optionally) verifies it uses the indicated driver
+* ``cukinia_imx6_fuse <bank> <word> [mask] <value>``: This checks the value of a fuse word on an i.MX6 SoC
 * ``cukinia_gpio_libgpiod -i [input_pins] -l [output_low_pins] -h [output_high_pins]
   -g [gpiochip](default:gpiochip0)``: Validate the gpio configuration via libgpiod
   (ex: cukinia_gpio_libgpiod -i "0 3 4" -l "10" -h "2 50" -g gpiochip1)

--- a/cukinia
+++ b/cukinia
@@ -21,6 +21,7 @@ GENERIC_FUNCTS='cmd
 		group
 		http_request
 		i2c
+		imx6_fuse
 		kconf
 		kmod
 		knoerror
@@ -920,6 +921,42 @@ _cukinia_i2c()
 
 	[ "$(readlink -f "$link")" = "$(readlink -f "$target")" ] && return 0 || return 1
 }
+
+_cukinia_imx6_fuse()
+{
+    local bank="$1"
+    local word="$2"
+    local skip="$((bank * 8 + word))"
+    local mask
+    local test_value
+    local value
+
+    if [ $# -gt 3 ]; then
+        mask="$3"
+        test_value="$4"
+    else
+        test_value="$3"
+    fi
+
+    if [ -z "$mask" ]; then
+        _cukinia_prepare "Checking i.MX6 fuse bank $bank word $word is ${__not:+NOT }set to $test_value"
+    else
+        _cukinia_prepare "Checking i.MX6 fuse bank $bank word $word is ${__not:+NOT }set to $test_value (masked by $mask)"
+    fi
+
+    if [ ! -f /sys/bus/nvmem/devices/imx-ocotp0/nvmem ]; then
+        return 1
+    fi
+
+    value=0x$(dd status=none if=/sys/bus/nvmem/devices/imx-ocotp0/nvmem of=/dev/stdout bs=4 count=1 skip="$skip" 2> /dev/null | hexdump -v -e '4/4 "%08x" "\n"' | tr -d ' ')
+
+    if [ -n "$mask" ]; then
+        value=$(($value & $mask))
+    fi
+
+    [ $(($value)) = $(($test_value)) ] && return 0 || return 1
+}
+
 
 # _cukinia_gpio_libgpiod: Check gpio configuration via libgpiod
 # arg1: (optional) the pins configured in input


### PR DESCRIPTION
The fuses can be read in the sysfs using the nvmem device. It is enabled by adding the configuration CONFIG_NVMEM_IMX_OCOTP in the kernel. The read value is retrieved following this guide [1].

This should work on i.MX8 as well, but it has not been tested.

[1]: https://www.digi.com/resources/documentation/digidocs/embedded/dey/4.0/cc6/bsp-otp_r_cc6cc6qp.html