### PR TITLE
_cukinia_mount: fix awk getting stuck when used with nullglob

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -911,7 +911,7 @@ _cukinia_mount()
 	fi
 
 	result=$(awk '
-		$1 == "'$device'" && $2 == "'$mountpoint'" && $3 ~ /^'$fstype'$/ {
+		$1 == "'$device'" && $2 == "'$mountpoint'" && $3 ~ /^'"$fstype"'$/ {
 			print $4;
 		}' /proc/mounts | sort | uniq)
 


### PR DESCRIPTION
Fixes cukinia_mount getting stuck when 'shopt -s nullglob' is used before it.
Fixes https://github.com/savoirfairelinux/cukinia/issues/86