### PR TITLE
cukinia_mount: shift 3 when fstype is provided

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -896,7 +896,7 @@ _cukinia_mount()
 	local found=0
 	local result
 
-	if [ "$#" -gt 3 ]; then
+	if [ "$#" -ge 3 ]; then
 		shift 3
 		options="$*"
 	else

--- a/tests/testcases.conf
+++ b/tests/testcases.conf
@@ -64,6 +64,7 @@ not cukinia_sysctl fs.protected_fifos 2
 section "cukinia_mount"
 
 cukinia_mount proc /proc
+cukinia_mount proc /proc proc
 cukinia_mount proc /proc proc rw,nosuid,nodev,noexec,relatime
 not cukinia_mount /dev/nonexistent /mnt
 


### PR DESCRIPTION
Currently, when the fstype is provided, "$#" equals 3 and so the `-gt` test fails and `shift 2` is applied whereas `shift 3` should be applied.

This is to resolve #91 