### PR TITLE
cukinia_i2c: correctly format device address for driver check

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -568,7 +568,13 @@ _cukinia_python_pkg()
 	fi
 
 	_cukinia_prepare "Checking python package \"$package\" is ${__not:+NOT }available"
-	"$python_interpreter" -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader('$package') else 1)"
+
+	local check_module="import sys, pkgutil; sys.exit(0 if pkgutil.find_loader('$package') else 1)"
+	if [ ! $("$python_interpreter" -c 'exec("try:from pkgutil import find_loader\nexcept:exit(1)")') ]; then
+		check_module="import sys, importlib; sys.exit(0 if importlib.util.find_spec('$package') else 1)"
+	fi
+
+	"$python_interpreter" -c "$check_module"
 }
 
 # _cukinia_prepare: Prepare test for result

--- a/cukinia
+++ b/cukinia
@@ -974,7 +974,7 @@ _cukinia_i2c()
 		return 0
 	fi
 
-	local device_path=$bus_number-$(printf '%0'4'd' $device_address)
+	local device_path=$bus_number-$(printf '%0'4'x' 0x$device_address)
 	local link=/sys/bus/i2c/devices/$device_path/driver
 	local target=/sys/bus/i2c/drivers/$driver_name
 

--- a/tests/testcases.conf
+++ b/tests/testcases.conf
@@ -101,7 +101,7 @@ not cukinia_listen4 tcp 63530
 
 section "network interface configuration"
 
-gw_if=$(route -n | awk '/^0.0.0.0/ { print $8 }')
+gw_if=$(route -n | awk '/^0.0.0.0/ { print $8 }' | head -n1)
 cukinia_netif_has_ip $gw_if
 not cukinia_netif_has_ip bad_if_name
 cukinia_netif_is_up  $gw_if


### PR DESCRIPTION
Treat the device address as a hex number when calling printf to
determine the device path and check the driver.

Consider a device defined like this in the device tree:

	device: device@5e {
		compatible = "somedriver";
		reg = <0x5e>;
		...
	}

This results in the following path `/sys/bus/i2c/devices/i2c-0/0-005e`.

This is defined in the device tree spec, section 2.2.1.1 Node Name
Requirements. The node name should be node-name@unit-address, and the
unit-address must be the first address in the reg property, 0x5e above.

Before this change, the following test would fail:

cukinia_i2c 0 0x5e somedriver

There were two problems:

1. printf would fail silentily since $device_address was stripped of the
   0x prefix and would not be recognized as a number if it was a
   hexadecimal
    ```
    $ printf '%0'4'd' 5e
    -bash: printf: 5e: invalid number
    0005
    ```
2. The format string in printf would expect a decimal number, resulting
   in the wrong path being built
    ```
    $ printf '%0'4'd' 0x5e
    0094
    $ printf '%0'4'x' 0x5e
    005e
    ```