### PR TITLE
cukinia: allow newlines in system-out and system-err CDATA sections

### DIFF
--- a/cukinia
+++ b/cukinia
@@ -1507,14 +1507,14 @@ EOF
 
 	if [ -s "$__stderr_tmp" ]; then
 		cat >>"$logfile" <<EOF
-      <system-err><![CDATA[$(cat $__stderr_tmp | tr -dc [:print:])]]></system-err>
+      <system-err><![CDATA[$(cat $__stderr_tmp | tr -dc '[:print:]\n')]]></system-err>
 EOF
 	> $__stderr_tmp
 	fi
 
 	if [ -s "$__stdout_tmp" ]; then
 		cat >>"$logfile" <<EOF
-      <system-out><![CDATA[$(cat $__stdout_tmp | tr -dc [:print:])]]></system-out>
+      <system-out><![CDATA[$(cat $__stdout_tmp | tr -dc '[:print:]\n')]]></system-out>
 EOF
 	> $__stdout_tmp
 	fi

--- a/tests/testcases.conf
+++ b/tests/testcases.conf
@@ -160,8 +160,10 @@ section "when/unless"
 machine_is() { test "$(uname -m)" = "$1"; }
 on_eval_board() { grep -q EVK /sys/firmware/devicetree/base/model 2>/dev/null; }
 
+day=$(date +%d)
+day=${day#0}
 when "machine_is x86_64" \
-  unless "[ $(( $(date +%d) % 2)) -eq 0 ]" \
+  unless "[ $(( day % 2)) -eq 0 ]" \
     as "Should PASS on x86_64 PC only or skip on even days" \
       cukinia_cmd /bin/true
 


### PR DESCRIPTION
To ease the printing of multi-line output in the system-out and system-err CDATA sections, allow newlines to be included in the output by adding '\n' to the tr command that filters out non-printable characters. This change will enable better readability of the output in the XML report generated by Cukinia.